### PR TITLE
fix Cydia Warning

### DIFF
--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: org.thebigboss.libstatus9
 Name: libstatus9
-Provides: libstatusbar (=0.9.9.0) ,libmoorecon (=0.9.9.0)
+Provides: libstatusbar ,libmoorecon
 Replaces: libstatusbar ,libmoorecon
 Conflicts: libstatusbar,libmoorecon
 Depends: firmware (>=9.1), mobilesubstrate, com.rpetrich.rocketbootstrap


### PR DESCRIPTION
Currently apt throws a warning about the Provides line in the control file.
This means that Cydia is unable to use libstatus9 as an improvement over libstatusbar/libmoorecon,
resulting in unwanted behaviour:
Instead of installing libstatus9 as a dependency for tweaks that rely on libstatusbar/libmoorecon, it simply conflicts with those libraries. Thus installing libstatus9 will result in the removal of libstatusbar/libmoorecon AND the tweaks that rely on these libraries.

This is the result of either a syntax error in the control file at the "Provides..." line, or a bug in apt itself. Meanwhile, removing the version specification fixes this issue.